### PR TITLE
Updatea semver word-wrap versions to fix security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1503,7 +1503,7 @@
         "minimatch": "^3.1.2",
         "object.values": "^1.1.6",
         "resolve": "^1.22.1",
-        "semver": "^6.3.0",
+        "semver": "^6.3.1",
         "tsconfig-paths": "^3.14.1"
       },
       "engines": {
@@ -1533,7 +1533,7 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
@@ -1560,7 +1560,7 @@
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.6",
         "object.fromentries": "^2.0.6",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=4.0"
@@ -1570,7 +1570,7 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
@@ -1595,7 +1595,7 @@
         "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.4",
-        "semver": "^6.3.0",
+        "semver": "^6.3.1",
         "string.prototype.matchall": "^4.0.8"
       },
       "engines": {
@@ -1644,7 +1644,7 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
@@ -3063,7 +3063,7 @@
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "word-wrap": "^1.2.4"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -4194,7 +4194,7 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "engines": {
@@ -5239,7 +5239,7 @@
         "minimatch": "^3.1.2",
         "object.values": "^1.1.6",
         "resolve": "^1.22.1",
-        "semver": "^6.3.0",
+        "semver": "^6.3.1",
         "tsconfig-paths": "^3.14.1"
       },
       "dependencies": {
@@ -5260,7 +5260,7 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
@@ -5286,11 +5286,11 @@
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.6",
         "object.fromentries": "^2.0.6",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
@@ -5314,7 +5314,7 @@
         "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.4",
-        "semver": "^6.3.0",
+        "semver": "^6.3.1",
         "string.prototype.matchall": "^4.0.8"
       },
       "dependencies": {
@@ -5337,7 +5337,7 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
+          "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
@@ -6288,7 +6288,7 @@
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "word-wrap": "^1.2.4"
       }
     },
     "p-limit": {
@@ -7016,7 +7016,7 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },


### PR DESCRIPTION
- Updates semver version from 6.0.0 to 6.3.1
- Updates word-wrap version from less than 1.2.4 to 1.2.4